### PR TITLE
Pre-allocate `d` and add factorization check

### DIFF
--- a/src/CaNNOLeS.jl
+++ b/src/CaNNOLeS.jl
@@ -408,6 +408,8 @@ function SolverCore.solve!(
         if ρ > params[:ρmax] || !newton_success || any(isinf.(d)) || any(isnan.(d)) || fx ≥ T(1e60) # Error on hs70
           internal_msg = if ρ > params[:ρmax]
             "ρ → ∞"
+          elseif !newton_success
+            "Failure in Newton step computation"
           elseif any(isinf.(d))
             "d → ∞"
           elseif any(isnan.(d))

--- a/src/solver_types.jl
+++ b/src/solver_types.jl
@@ -12,8 +12,8 @@ if isdefined(HSL, :libhsl_ma57)
   end
 
   get_vals(LDLT::MA57Struct) = LDLT.factor.vals
-  function solve(rhs::AbstractVector, factor::Ma57)
-    d = ma57_solve(factor, -rhs)
+  function solve!(rhs::AbstractVector, factor::Ma57, d::AbstractVector)
+    d .= ma57_solve(factor, -rhs)
     return d, true
   end
 else
@@ -35,8 +35,8 @@ end
 
 get_vals(LDLT::LinearSolverStruct) = LDLT.vals
 
-solve(::AbstractVector, factor::Nothing) = error("LDLt factorization failed.")
-function solve(rhs::AbstractVector, factor::LDLFactorizations.LDLFactorization)
-  d = -(factor \ rhs)
+solve!(::AbstractVector, factor::Nothing, ::AbstractVector) = error("LDLt factorization failed.")
+function solve!(rhs::AbstractVector, factor::LDLFactorizations.LDLFactorization, d::AbstractVector)
+  d .= -(factor \ rhs)
   return d, true
 end


### PR DESCRIPTION
Preallocate `d` for a first step the in-place Newton system solve.
This allows returning an `:exception` status if the factorization failed, connected to #43 
