### PR TITLE
Fix bug in unit tests without LDL

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -129,7 +129,7 @@ end
     name = "HS6",
   )
   stats = GenericExecutionStats(nls)
-  solver = CaNNOLeSSolver(nls)
+  solver = CaNNOLeSSolver(nls, linsolve = :ldlfactorizations)
   solve!(solver, nls, stats, check_small_residual = true)
   @test stats.status_reliable && stats.status == :small_residual
   @test stats.objective_reliable && isapprox(stats.objective, 0, atol = 1e-6)


### PR DESCRIPTION
Follow-up #92 
With `HSL` we have a first-order stationary, while I wanted to check small residual.