### PR TITLE
Remove allocations in intro

### DIFF
--- a/src/CaNNOLeS.jl
+++ b/src/CaNNOLeS.jl
@@ -905,8 +905,8 @@ end
 Return `true` if `x` contains `NaN` or `Inf`.
 """
 function check_nan_inf(x)
-  for i = 1:length(x)
-    if isnan(x[i]) || isinf(x)
+  for i in eachindex(x)
+    if isnan(x[i]) || isinf(x[i])
       return true
     end
   end

--- a/src/CaNNOLeS.jl
+++ b/src/CaNNOLeS.jl
@@ -507,7 +507,7 @@ function SolverCore.solve!(
   dual = solver.dual .= Jxtr .- Jcxtλ
   primal = solver.primal
   primal[1:nequ] .= Fx .- r
-  primal[nequ:end] .= cx
+  primal[(nequ + 1):end] .= cx
 
   rhs = solver.rhs
 
@@ -896,7 +896,7 @@ function optimality_check_small_residual!(
   normdual = norm(dual, Inf)
   nequ = length(r)
   primal[1:nequ] .= zero(T)
-  primal[nequ:end] .= cx
+  primal[(nequ + 1):end] .= cx
   normprimal = norm(cx, Inf)
   return normprimal, normdual
 end


### PR DESCRIPTION
When starting form a solution, only `set_solver_specific!` allocates now