### PR TITLE
Import NLPModels.get_nnzh

### DIFF
--- a/src/hessian_approx.jl
+++ b/src/hessian_approx.jl
@@ -1,5 +1,7 @@
 abstract type HessianStruct{Ti} end
 
+import NLPModels.get_nnzh
+
 """
     get_nnzh(::HessianStruct)
 

--- a/src/hessian_approx.jl
+++ b/src/hessian_approx.jl
@@ -1,18 +1,9 @@
 abstract type HessianStruct{Ti} end
 
-import NLPModels.get_nnzh
-
 """
     get_nnzh(::HessianStruct)
 
 Return number of nonzeros in the approximatation of the Hessian.
-"""
-function get_nnzh end
-
-"""
-    get_structure(::HessianStruct)
-
-Return the structure of the approximatation of the Hessian.
 """
 function get_nnzh end
 


### PR DESCRIPTION
```
┌ CaNNOLeS [5a1c9e79-9c58-5ec0-afc4-3298fdea2875]
│  ┌ Warning: Replacing docs for `CaNNOLeS.get_nnzh :: Union{}` in module `CaNNOLeS`
│  └ @ Base.Docs docs/Docs.jl:243
└  
```